### PR TITLE
Adding missing module match for temperature trend

### DIFF
--- a/dashboard.json
+++ b/dashboard.json
@@ -2083,7 +2083,12 @@
               "key": "station",
               "operator": "=~",
               "value": "/^$Station$/"
-            }
+            },
+            {
+              "condition": "AND",
+              "key": "module",
+              "operator": "=~",
+              "value": "/^$Module$/"
           ]
         }
       ],


### PR DESCRIPTION
I noticed that the singlestat for Temperature Trend was only matching on station, not on station and module. As a result, the display didn't show temperature trend properly for the outdoors station. This PR adds in the needed code to match on module as well.