### PR TITLE
custom influxdb usage

### DIFF
--- a/netatmo_influx.py
+++ b/netatmo_influx.py
@@ -13,7 +13,7 @@ import json
 #     "INFLUX_HOST" : "",
 #     "INFLUX_PORT" : "",
 #   }
-INFLUXCONFIG = "~/.netatmo.mysql"
+INFLUXCONFIG = "~/.netatmo.influxdb"
 
 if (INFLUXCONFIG):
   influxconfigFile = expanduser(INFLUXCONFIG)

--- a/netatmo_influx.py
+++ b/netatmo_influx.py
@@ -6,7 +6,15 @@ from influxdb import InfluxDBClient
 from os.path import expanduser, exists
 import json
 
+#
+#  custom influx config file
+#
+#   {
+#     "INFLUX_HOST" : "",
+#     "INFLUX_PORT" : "",
+#   }
 INFLUXCONFIG = "~/.netatmo.mysql"
+
 if (INFLUXCONFIG):
   influxconfigFile = expanduser(INFLUXCONFIG)
   with open(influxconfigFile, "r") as f:
@@ -17,15 +25,14 @@ if (INFLUXCONFIG):
 else:
   #print("default")
   client = InfluxDBClient()
+  if {'name': 'netatmo'} not in client.get_list_database():
+    client.create_database('netatmo')
 
 authorization = lnetatmo.ClientAuth()
 
 weatherData = lnetatmo.WeatherStationData(authorization)
 
-if {'name': 'netatmo'} not in client.get_list_database():
-    client.create_database('netatmo')
-
-print(weatherData.stationByName())
+#print(weatherData.stationByName())
 for station in weatherData.stations:
     station_data = []
     module_data = []

--- a/netatmo_influx.py
+++ b/netatmo_influx.py
@@ -3,15 +3,29 @@
 
 import lnetatmo
 from influxdb import InfluxDBClient
+from os.path import expanduser, exists
+import json
+
+INFLUXCONFIG = "~/.netatmo.mysql"
+if (INFLUXCONFIG):
+  influxconfigFile = expanduser(INFLUXCONFIG)
+  with open(influxconfigFile, "r") as f:
+      influxconfig = {k.upper():v for k,v in json.loads(f.read()).items()}
+
+  #print(influxconfig)
+  client = InfluxDBClient(host=influxconfig["INFLUX_HOST"], port=influxconfig["INFLUX_PORT"])
+else:
+  #print("default")
+  client = InfluxDBClient()
 
 authorization = lnetatmo.ClientAuth()
 
 weatherData = lnetatmo.WeatherStationData(authorization)
 
-client = InfluxDBClient()
 if {'name': 'netatmo'} not in client.get_list_database():
     client.create_database('netatmo')
 
+print(weatherData.stationByName())
 for station in weatherData.stations:
     station_data = []
     module_data = []


### PR DESCRIPTION
A custom influxdb can be used in place of the default one.
All the details for the influxdb are stored in a json file with the following format:
{
  "INFLUX_HOST" : "",
  "INFLUX_PORT" : "",
}

By default this file is store in  ~/.netatmo.influxdb